### PR TITLE
Adding functionality to limit form submission by IP

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -38,15 +38,15 @@ app.get('/', function (req, res) {
 
 app.post('/', async function (req, res) {
 	
+	// First, set the user ip
+	let userIP = req.ip;
+
 	// Grab and print date/time and IP of user upon form submission/post
 	let submitDate = new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
 
-	console.log('IP', req.ip);
+	console.log('IP', userIP);
 	console.log('DATE', submitDate);
 
-
-	// first check if IP has submitted in the last 12 hours and return an error if so
-	let userIP = req.ip;
 
 	// Next see if that user has already submitted within the last 24 hours
 	try {

--- a/server.ts
+++ b/server.ts
@@ -18,11 +18,52 @@ app.use(express.static('public'));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.set('view engine', 'ejs');
 
+// If we are using a proxy, uncommenting the below line allows the app to get the real IP through the proxy and is necessary for limiting req by IP
+// app.set('trust proxy', true);
+
+// Initialize user array outside of get / post
+let users = new Array();
+
+// adding clear function for our IP list
+function clearFunc() {
+	console.log('clearing the users array, its been 12 hours');
+	users = [];
+}
+// set interval to run clearFunc every 12 hours in milliseconds
+setInterval(clearFunc, 43200000);
+
 app.get('/', function (req, res) {
 	res.render('index', { txid: null, error: null });
 })
 
 app.post('/', async function (req, res) {
+	
+	// Grab and print date/time and IP of user upon form submission/post
+	let submitDate = new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
+
+	console.log('IP', req.ip);
+	console.log('DATE', submitDate);
+
+
+	// first check if IP has submitted in the last 12 hours and return an error if so
+	let userIP = req.ip;
+
+	// Next see if that user has already submitted within the last 24 hours
+	try {
+		if(users.indexOf(userIP) != -1) {
+		// user already exists in array, send back error and return
+		console.log('User already submitted form in last 12 hours, sending back error message');
+			res.render('index', { txid: null, error: "You may only claim SOUR from the faucet once per 12 hours. Check back soon!"});
+		return;
+			}
+	}
+	catch(error) {
+		console.log(error);
+		return;
+    	}
+
+	// We checked the IP and its good, resume.
+
 	let address = req.body.address;
 
 	if(address === process.env.DISTRIBUTE_SECRET!) {
@@ -70,6 +111,13 @@ app.post('/', async function (req, res) {
 		res.render('index', { txid: null, error: sendTxId });
 		return;
 	}
+
+	// tx was successful and  user IP doesn't exist in the array yet so let's add them
+    console.log('adding new user to array');
+    users.push(userIP);
+    // print all users IPs as we add them
+    console.log('printing all users IPs:');
+	console.log(users);
 
 	res.render('index', { txid: sendTxId, error: null });
 })


### PR DESCRIPTION
In the added functionality, 1 request by an IP is allowed per 12 hours otherwise we return an error. When a user submits the form, their IP is checked against the users array. If the IP is found, an error is returned. Otherwise, when a request is successfully processed, we are adding the userIP into an array.  The array is cleared every 12 hours. If the server is restarted then the array will also be cleared. I also included functionality to grab IP address through proxy, if one is being used then it needs to be uncommented. If there are any issues, let me know and I'll work on fixing them. I have tested it & it is working great on my production SOUR SLP Faucet currently at http://slp-faucet.ddns.net