### PR TITLE
Distribute NFT child tokens with burning the qty=1 parent ones

### DIFF
--- a/faucet_utils.ts
+++ b/faucet_utils.ts
@@ -47,8 +47,8 @@ export class FaucetUtils {
 
         const name = process.env.NFTNAME! || "SLP Faucet NFT";
         const ticker = process.env.NFTTICKER! || "SFNFT";
-        const documentUri: string|null = process.env.DOCUMENTURI!;
-        const documentHash: Buffer|null = Buffer.from(process.env.DOCUMENTHASH!, 'hex');
+        const documentUri: string|null = process.env.DOCUMENTURI || null;
+        const documentHash: Buffer|null = process.env.DOCUMENTHASH ? Buffer.from(process.env.DOCUMENTHASH, 'hex') : null;
 
         const genesisTxHex = this.network.txnHelpers.simpleNFT1ChildGenesis({
             nft1GroupId: tokenId,

--- a/faucet_utils.ts
+++ b/faucet_utils.ts
@@ -1,0 +1,76 @@
+import { BITBOX } from "bitbox-sdk";
+import * as slpjs from "slpjs";
+import { BchdNetwork, BchdValidator } from "slpjs";
+import { BigNumber } from "bignumber.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class FaucetUtils {
+    public network: BchdNetwork;
+
+    constructor (bitbox: BITBOX, validator: BchdValidator) {
+        this.network = new BchdNetwork({ BITBOX: bitbox, validator, logger: console, client: validator.client });
+    }
+
+    public async nftTokenSend(tokenId: string, inputUtxos: slpjs.SlpAddressUtxoResult[], tokenReceiverAddress: string, paymentAddress: string, paymentAddressWif: string): Promise<string> {
+        let burnUtxo: slpjs.SlpAddressUtxoResult | undefined = undefined;
+        inputUtxos.forEach((txo) => {
+            if (!burnUtxo && txo.slpUtxoJudgement === 'SLP_TOKEN' && txo.slpUtxoJudgementAmount.isEqualTo(1)) {
+                burnUtxo = txo;
+            }
+        })
+        // ---[ TODO: optimize this part to send both transactions with one call ]---
+        if (!burnUtxo) {
+            const burnTxHex = await this.network.txnHelpers.simpleTokenSend({
+                tokenId,
+                sendAmounts: [ new BigNumber(1) ],
+                inputUtxos,
+                tokenReceiverAddresses: [ paymentAddress ],
+                changeReceiverAddress: paymentAddress
+            })
+            const burnTxId: string = await this.network.sendTx(burnTxHex);
+            console.log(`burn tx: ${burnTxId}`);
+            console.log(`wait sync...`);
+            await sleep(3000);
+        }
+
+        const balances: slpjs.SlpBalancesResult = (await this.network.getAllSlpBalancesAndUtxos(paymentAddress) as slpjs.SlpBalancesResult);
+        balances.slpTokenUtxos[tokenId].forEach((txo) => {
+            if (!burnUtxo && txo.slpUtxoJudgementAmount.isEqualTo(1)) {
+                burnUtxo = txo;
+            }
+        });
+        if (!burnUtxo) throw new Error('No token ready for burn');
+
+        const inputs = [burnUtxo, ...balances!.nonSlpUtxos] as slpjs.SlpAddressUtxoResult[];
+        inputs.forEach((j) => j.wif = paymentAddressWif);
+
+        const name = process.env.NFTNAME! || "SLP Faucet NFT";
+        const ticker = process.env.NFTTICKER! || "SFNFT";
+        const documentUri: string|null = process.env.DOCUMENTURI!;
+        const documentHash: Buffer|null = Buffer.from(process.env.DOCUMENTHASH!, 'hex');
+
+        const genesisTxHex = this.network.txnHelpers.simpleNFT1ChildGenesis({
+            nft1GroupId: tokenId,
+            tokenName: name,
+            tokenTicker: ticker,
+            documentUri,
+            documentHash,
+            tokenReceiverAddress: tokenReceiverAddress,
+            bchChangeReceiverAddress: paymentAddress,
+            inputUtxos: inputs
+          })
+        // console.log(`genesis hex: ${JSON.stringify(genesisTxHex, null, 2)}`)
+        const burn = {
+            tokenId: Buffer.from(tokenId, 'hex'),
+            tokenType: 129,
+            amount: '1',
+            outpointHash: Buffer.from(Buffer.from(burnUtxo!.txid, 'hex').reverse()),
+            outpointVout: burnUtxo!.vout
+        }
+
+        const genesisTxId = await this.network.sendTx(genesisTxHex, [burn]);
+        console.log('NFT1 Child GENESIS txn complete: ', genesisTxId);
+        return genesisTxId;
+    }
+}

--- a/server.ts
+++ b/server.ts
@@ -70,7 +70,7 @@ app.post("/", async (req, res) => {
         let inputs: slpjs.SlpAddressUtxoResult[] = [];
         inputs = inputs.concat(changeAddr.balance.slpTokenUtxos[process.env.TOKENID!]).concat(changeAddr.balance.nonSlpUtxos);
         inputs.map((i) => i.wif = slpFaucet.wifs[changeAddr.address]);
-        sendTxId = await slpFaucet.simpleTokenSend(process.env.TOKENID!, new BigNumber(faucetQty), inputs, address, changeAddr.address);
+        sendTxId = await slpFaucet.tokenSend(process.env.TOKENID!, new BigNumber(faucetQty), inputs, address, changeAddr.address);
     } catch (error) {
         console.log(error);
         res.render("index", { txid: null, error: "Server error." });

--- a/slpfaucet.ts
+++ b/slpfaucet.ts
@@ -148,7 +148,7 @@ export class SlpFaucetHandler {
 
     public async tokenSend(tokenId: string, sendAmount: BigNumber, inputUtxos: slpjs.SlpAddressUtxoResult[], tokenReceiverAddresses: string | string[], changeReceiverAddress: string): Promise<string> {
         await this.increaseChainLength();
-        if (process.env.NFT === 'yes') {
+        if (process.env.NFT!.toLowerCase() === 'yes') {
             const receiverAddress = (typeof tokenReceiverAddresses === 'string') ? tokenReceiverAddresses : tokenReceiverAddresses[0];
             return await faucetUtils.nftTokenSend(tokenId, inputUtxos, receiverAddress, changeReceiverAddress, this.wifs[changeReceiverAddress]);
         }


### PR DESCRIPTION
The code from PR #2 require too many changes. The branch will be closed and the current one will replace it.

The goals for this PR:

- As little changes as possible to the original code:
  - `server.ts` - just one function change to point to a wrapper function generating NFTs and usual tokens
  - `slpfaucet.ts` - a small wrapper function - `tokenSend()`
 - No NFT logic in `server.ts` - should be unaware what kind of tokens are distributed
 - All NFT logic extracted in a separate file - `faucet_utils.ts` contains all NFT related code (in fact just **one function**)

The faucet is working as it is now. As a future performance optimization (in a separate PR maybe) will try to combine creating single quantity parent token UTXO and NFT child token genesis in one call to the blockchain.